### PR TITLE
Adds a smarter way to read configuration information from a command-line

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,73 @@
+Optional `files` configuration system
+=====================================
+
+The `impactlab_tools` repository contains a general system for passing
+configuration information to scripts, and this is used by a few of the
+existing repositories.  New repositories are welcome to use it, if
+they choose.  The features of the system are:
+
+ - Individual jobs are run with configuration dictionaries, which
+   specify the mode or targets of their work.
+ - These configuration options are usually specified on the
+   command-line, and can be read from `.yml` files, from individual
+   configuration arguments on the command line, or both.
+ - Optionally, an additional "server configuration" file specifies a
+   shared data directory on the job server, allowing files there to be
+   accessed more easily.
+
+Job configurations
+------------------
+
+The configuration options for individual jobs are usually specified on
+the command-line, and accessed through the
+`files.get_allargv_config()` function.  The
+`files.get_allargv_config()` function builds a single configuration
+dictionary from arguments according to the following rules:
+
+ - `FILE.yml`: a full configuration YaML file, merged into the result dictionary
+ - `--config=FILE.yml`: a full configuration YaML file, as above
+ - `--KEY=VALUE`: a single configuration value to be set
+ - anything else: sets an entry in the config file for that anything to have a value of True
+
+Alternatively, `files.get_file_config(filepath)` can be used to just
+read in a `.yml` configuration file.
+
+Shared directory handling
+-------------------------
+
+Typically, each job-running machine has a common root directory
+containing data for multiple jobs and multiple users.  These
+directories are as follows for the common GCP servers:
+
+ - Sacagawea: `/shares/gcp`
+ - OSDC: `/mnt/gcp`
+ - BRC: `/global/scratch/<username>`
+
+Having a server-level configured shared data directory allows the same
+job to be run on multiple servers without changes to either the job
+code or job-level configuration.
+
+Individual users and individual jobs can specify their own common data
+root directories, though this is generally not efficient.  Below, the
+"server configuration" refers to all options that are generally
+thought of as bein shared across all users and jobs on a server, but
+this need not be the case.
+
+The server configuration currently supports only one server-level
+configuration option: `shareddir`, which is the root data directory
+described above.
+
+Once the server configuration is specified, the function
+`files.configpath(path)` can be used to construct absolute paths to
+data files.  If `path` is a relative path (not starting with a `/`),
+the path returned is given as relative to the server data directory.
+Otherwise, it is returned unchanged.  (This second case occurs, for
+example, when job confiuration files specify arbitrary output
+directories, which may or may not be relative to the shared data
+directory.)
+
+The server configuration can be set by setting `files.server_config`
+to a dictionary containing the `shareddir` key.  Alternatively, a file
+titled `server.yml` can be stored one directory above any job
+repository directory; if `files.server_config` is not set, this file
+will be looked for.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,7 +1,7 @@
-Optional `files` configuration system
+Optional :code:`files` configuration system
 =====================================
 
-The `impactlab_tools` repository contains a general system for passing
+The :code:`impactlab_tools` repository contains a general system for passing
 configuration information to scripts, and this is used by a few of the
 existing repositories.  New repositories are welcome to use it, if
 they choose.  The features of the system are:
@@ -9,7 +9,7 @@ they choose.  The features of the system are:
  - Individual jobs are run with configuration dictionaries, which
    specify the mode or targets of their work.
  - These configuration options are usually specified on the
-   command-line, and can be read from `.yml` files, from individual
+   command-line, and can be read from :bash:`.yml` files, from individual
    configuration arguments on the command line, or both.
  - Optionally, an additional "server configuration" file specifies a
    shared data directory on the job server, allowing files there to be
@@ -20,17 +20,17 @@ Job configurations
 
 The configuration options for individual jobs are usually specified on
 the command-line, and accessed through the
-`files.get_allargv_config()` function.  The
-`files.get_allargv_config()` function builds a single configuration
+:code:`files.get_allargv_config()` function.  The
+:code:`files.get_allargv_config()` function builds a single configuration
 dictionary from arguments according to the following rules:
 
- - `FILE.yml`: a full configuration YaML file, merged into the result dictionary
- - `--config=FILE.yml`: a full configuration YaML file, as above
- - `--KEY=VALUE`: a single configuration value to be set
+ - :bash:`FILE.yml`: a full configuration YaML file, merged into the result dictionary
+ - :bash:`--config=FILE.yml`: a full configuration YaML file, as above
+ - :bash:`--KEY=VALUE`: a single configuration value to be set
  - anything else: sets an entry in the config file for that anything to have a value of True
 
-Alternatively, `files.get_file_config(filepath)` can be used to just
-read in a `.yml` configuration file.
+Alternatively, :code:`files.get_file_config(filepath)` can be used to just
+read in a :bash:`.yml` configuration file.
 
 Shared directory handling
 -------------------------
@@ -39,9 +39,9 @@ Typically, each job-running machine has a common root directory
 containing data for multiple jobs and multiple users.  These
 directories are as follows for the common GCP servers:
 
- - Sacagawea: `/shares/gcp`
- - OSDC: `/mnt/gcp`
- - BRC: `/global/scratch/<username>`
+ - Sacagawea: :bash:`/shares/gcp`
+ - OSDC: :bash:`/mnt/gcp`
+ - BRC: :bash:`/global/scratch/<username>`
 
 Having a server-level configured shared data directory allows the same
 job to be run on multiple servers without changes to either the job
@@ -54,20 +54,20 @@ thought of as bein shared across all users and jobs on a server, but
 this need not be the case.
 
 The server configuration currently supports only one server-level
-configuration option: `shareddir`, which is the root data directory
+configuration option: :code:`shareddir`, which is the root data directory
 described above.
 
 Once the server configuration is specified, the function
-`files.configpath(path)` can be used to construct absolute paths to
-data files.  If `path` is a relative path (not starting with a `/`),
+:code:`files.configpath(path)` can be used to construct absolute paths to
+data files.  If :code:`path` is a relative path (not starting with a :bash:`/`),
 the path returned is given as relative to the server data directory.
 Otherwise, it is returned unchanged.  (This second case occurs, for
 example, when job confiuration files specify arbitrary output
 directories, which may or may not be relative to the shared data
 directory.)
 
-The server configuration can be set by setting `files.server_config`
-to a dictionary containing the `shareddir` key.  Alternatively, a file
-titled `server.yml` can be stored one directory above any job
-repository directory; if `files.server_config` is not set, this file
+The server configuration can be set by setting :code:`files.server_config`
+to a dictionary containing the :code:`shareddir` key.  Alternatively, a file
+titled :bash:`server.yml` can be stored one directory above any job
+repository directory; if :code:`files.server_config` is not set, this file
 will be looked for.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,7 +9,7 @@ they choose.  The features of the system are:
  - Individual jobs are run with configuration dictionaries, which
    specify the mode or targets of their work.
  - These configuration options are usually specified on the
-   command-line, and can be read from :bash:`.yml` files, from individual
+   command-line, and can be read from :code:`.yml` files, from individual
    configuration arguments on the command line, or both.
  - Optionally, an additional "server configuration" file specifies a
    shared data directory on the job server, allowing files there to be
@@ -24,13 +24,13 @@ the command-line, and accessed through the
 :code:`files.get_allargv_config()` function builds a single configuration
 dictionary from arguments according to the following rules:
 
- - :bash:`FILE.yml`: a full configuration YaML file, merged into the result dictionary
- - :bash:`--config=FILE.yml`: a full configuration YaML file, as above
- - :bash:`--KEY=VALUE`: a single configuration value to be set
+ - :code:`FILE.yml`: a full configuration YaML file, merged into the result dictionary
+ - :code:`--config=FILE.yml`: a full configuration YaML file, as above
+ - :code:`--KEY=VALUE`: a single configuration value to be set
  - anything else: sets an entry in the config file for that anything to have a value of True
 
 Alternatively, :code:`files.get_file_config(filepath)` can be used to just
-read in a :bash:`.yml` configuration file.
+read in a :code:`.yml` configuration file.
 
 Shared directory handling
 -------------------------
@@ -39,9 +39,9 @@ Typically, each job-running machine has a common root directory
 containing data for multiple jobs and multiple users.  These
 directories are as follows for the common GCP servers:
 
- - Sacagawea: :bash:`/shares/gcp`
- - OSDC: :bash:`/mnt/gcp`
- - BRC: :bash:`/global/scratch/<username>`
+ - Sacagawea: :code:`/shares/gcp`
+ - OSDC: :code:`/mnt/gcp`
+ - BRC: :code:`/global/scratch/<username>`
 
 Having a server-level configured shared data directory allows the same
 job to be run on multiple servers without changes to either the job
@@ -59,7 +59,7 @@ described above.
 
 Once the server configuration is specified, the function
 :code:`files.configpath(path)` can be used to construct absolute paths to
-data files.  If :code:`path` is a relative path (not starting with a :bash:`/`),
+data files.  If :code:`path` is a relative path (not starting with a :code:`/`),
 the path returned is given as relative to the server data directory.
 Otherwise, it is returned unchanged.  (This second case occurs, for
 example, when job confiuration files specify arbitrary output
@@ -68,6 +68,6 @@ directory.)
 
 The server configuration can be set by setting :code:`files.server_config`
 to a dictionary containing the :code:`shareddir` key.  Alternatively, a file
-titled :bash:`server.yml` can be stored one directory above any job
+titled :code:`server.yml` can be stored one directory above any job
 repository directory; if :code:`files.server_config` is not set, this file
 will be looked for.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,5 +1,5 @@
-Optional :code:`files` configuration system
-=====================================
+Optional ``files`` configuration system
+=======================================
 
 The :code:`impactlab_tools` repository contains a general system for passing
 configuration information to scripts, and this is used by a few of the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,4 +17,5 @@ Contents
    readme
    whatsnew
    impactlab_tools
+   configuration
    contributing

--- a/impactlab_tools/utils/files.py
+++ b/impactlab_tools/utils/files.py
@@ -71,15 +71,15 @@ def get_argv_config(index=1):
 
 def get_allargv_config():
     """
-    Load a configuration from the command line, merging all arguments into a single configuration dictionary.
+Load a configuration from the command line, merging all arguments into a single configuration dictionary.
 
-    Handles the following kinds of command-line arguments:
-     - *.yml: a full configuration YaML file, merged into the result dictionary
-     - --config=VALUE: a full configuration YaML file, as above
-     - --KEY=VALUE: a single configuration value to be set
-     - anything else: sets an entry in the config file for that anything to have a value of True
+Handles the following kinds of command-line arguments:
+- *.yml: a full configuration YaML file, merged into the result dictionary
+- --config=VALUE: a full configuration YaML file, as above
+- --KEY=VALUE: a single configuration value to be set
+- anything else: sets an entry in the config file for that anything to have a value of True
 
-    Later command-line arguments always overide earlier ones.
+Later command-line arguments always overide earlier ones.
     """
     config = {}
     for arg in sys.argv:

--- a/impactlab_tools/utils/files.py
+++ b/impactlab_tools/utils/files.py
@@ -72,6 +72,28 @@ def get_argv_config(index=1):
         config = yaml.load(fp)
         return config
 
+def get_allargv_config():
+    config = {}
+    for arg in sys.argv:
+        if arg[-4:] == '.yml':
+            config.update(get_file_config(arg))
+            continue
 
+        if arg[0:2] == '--':
+            if '=' in arg:
+                chunks = arg[2:].split('=')
+                if chunks[0] == 'config':
+                    config = get_file_config(chunks[1])
+                else:
+                    config[chunks[0]] = yaml.load(chunks[1])
+            else:
+                config[arg[2:]] = True
+            continue
+        
+        config[arg] = True
+
+    return config
+                                                            
+    
 if __name__ == '__main__':
     print(configpath('testing'))

--- a/impactlab_tools/utils/files.py
+++ b/impactlab_tools/utils/files.py
@@ -71,15 +71,15 @@ def get_argv_config(index=1):
 
 def get_allargv_config():
     """
-Load a configuration from the command line, merging all arguments into a single configuration dictionary.
+    Load a configuration from the command line, merging all arguments into a single configuration dictionary.
 
-Handles the following kinds of command-line arguments:
-- *.yml: a full configuration YaML file, merged into the result dictionary
-- --config=VALUE: a full configuration YaML file, as above
-- --KEY=VALUE: a single configuration value to be set
-- anything else: sets an entry in the config file for that anything to have a value of True
+    Handles the following kinds of command-line arguments:
+    - `*.yml`: a full configuration YaML file, merged into the result dictionary
+    - `--config=VALUE`: a full configuration YaML file, as above
+    - `--KEY=VALUE`: a single configuration value to be set
+    - anything else: sets an entry in the config file for that anything to have a value of True
 
-Later command-line arguments always overide earlier ones.
+    Later command-line arguments always overide earlier ones.
     """
     config = {}
     for arg in sys.argv:
@@ -93,11 +93,11 @@ Later command-line arguments always overide earlier ones.
                 if chunks[0] == 'config':
                     config = get_file_config(chunks[1])
                 else:
-                    config[chunks[0]] = yaml.load(chunks[1])
+                    config[chunks[0]] = yaml.safe_load(chunks[1])
             else:
                 config[arg[2:]] = True
             continue
-        
+
         config[arg] = True
 
     return config

--- a/impactlab_tools/utils/files.py
+++ b/impactlab_tools/utils/files.py
@@ -43,6 +43,7 @@ def use_config(config):
     """Use the given configuration for path functions."""
     global server_config
 
+    # Add values from server_config only if not in config
     if server_config is not None:
         for key in server_config:
             if key not in config:
@@ -87,6 +88,7 @@ def get_allargv_config():
             config.update(get_file_config(arg))
             continue
 
+        # Add --key=value arguments one at a time
         if arg[0:2] == '--':
             if '=' in arg:
                 chunks = arg[2:].split('=')
@@ -101,6 +103,6 @@ def get_allargv_config():
         config[arg] = True
 
     return config
-                                                                
+
 if __name__ == '__main__':
     print(configpath('testing'))

--- a/impactlab_tools/utils/files.py
+++ b/impactlab_tools/utils/files.py
@@ -26,7 +26,6 @@ def sharedpath(subpath):
 
     return os.path.join(server_config['shareddir'], subpath)
 
-
 def configpath(path):
     """Return an configured absolute path.  If the path is absolute, it
     will be left alone; otherwise, it is assumed to be a subpath of the
@@ -51,14 +50,12 @@ def use_config(config):
 
     server_config = config
 
-
 def get_file_config(filepath):
     """Load a configuration file from a given path."""
 
     with open(filepath, 'r') as fp:
         config = yaml.load(fp)
         return config
-
 
 def get_argv_config(index=1):
     """
@@ -73,6 +70,17 @@ def get_argv_config(index=1):
         return config
 
 def get_allargv_config():
+    """
+    Load a configuration from the command line, merging all arguments into a single configuration dictionary.
+
+    Handles the following kinds of command-line arguments:
+     - *.yml: a full configuration YaML file, merged into the result dictionary
+     - --config=VALUE: a full configuration YaML file, as above
+     - --KEY=VALUE: a single configuration value to be set
+     - anything else: sets an entry in the config file for that anything to have a value of True
+
+    Later command-line arguments always overide earlier ones.
+    """
     config = {}
     for arg in sys.argv:
         if arg[-4:] == '.yml':
@@ -93,7 +101,6 @@ def get_allargv_config():
         config[arg] = True
 
     return config
-                                                            
-    
+                                                                
 if __name__ == '__main__':
     print(configpath('testing'))


### PR DESCRIPTION
Introduces a new function in files.py, `get_allargv_config`, which is a generalization of `get_argv_config` (which just reads a single configuration file from the command-line).  `get_allargv_config` can both read configuration files from the command line (multiple, overriding ones), and allow individual configuration values to be set on the command-line, using a `--KEY=VALUE` syntax.