### PR TITLE
add requirements file for RTD

### DIFF
--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+-r requirements_conda.txt
+-r requirements_dev.txt

--- a/whatsnew.rst
+++ b/whatsnew.rst
@@ -3,10 +3,16 @@ What's New
 
 These are new features and improvements of note in each release.
 
-v0.0.6 (Current Version)
+v0.0.7 (Current version)
 ------------------------
 
-  - add bin-by-value function (see :py:func:`impactlab_tools.utils.binning.binned_statistic_1d`)
+  - fix bug causing docs to fail when importing conda packages (:issue:`67`)
+  - add missing documentation for utils.binning module (finalizes :issue:`59`)
+
+v0.0.6 (August 16, 2017)
+------------------------
+
+  - add bin-by-value function (see :py:func:`impactlab_tools.utils.binning.binned_statistic_1d`) (:issue:`59`)
 
 v0.0.5 (February 23, 2017)
 ----------------------------


### PR DESCRIPTION
 - [x] closes #67 
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 impactlab_tools tests docs``
 - [x] whatsnew entry

Fix bug causing readthedocs module autodoc to fail when module relies on conda dependencies. Tests weren't catching this because local tests had installed all dependencies already. This fix patches this dependency management system, so tests will now properly catch import & docs errors.