### PR TITLE
Minor changes to versioning tool and paralog

### DIFF
--- a/impactlab_tools/utils/paralog.py
+++ b/impactlab_tools/utils/paralog.py
@@ -61,7 +61,7 @@ class StatusManager(object):
             with open(os.path.join(logdir, "master.log"), 'a') as fp:
                 fp.write("%s %s: %d %s\n" % (time.asctime(), self.jobtitle, os.getpid(), self.logpath))
         except:
-            print "Warning: Could not append to master log."
+            print("Warning: Could not append to master log.")
             
         # Grab all std out
         self.sys_stdout = sys.stdout
@@ -95,20 +95,20 @@ class StatusManager(object):
             with open(status_path, 'a') as fp:
                 fp.write(status + '\n')
         except:
-            print "Warning: Could write status update %s" % status
+            print("Warning: Could write status update %s" % status)
 
     def release(self, dirpath, status):
         """Release the claim on this directory."""
         try:
             os.remove(StatusManager.claiming_filepath(dirpath, self.jobname))
         except:
-            print "Warning: Could not release directory."
+            print("Warning: Could not release directory.")
 
         try:
             with open(StatusManager.globalstatus_filepath(dirpath), 'a') as fp:
                 fp.write("%s %s: %s\n" % (time.asctime(), self.jobtitle, status))
         except:
-            print "Warning: Could write release status %s" % status
+            print("Warning: Could write release status %s" % status)
 
     def is_claimed(self, dirname):
         """Check if a directory has claims from any of our jobs."""

--- a/impactlab_tools/utils/paralog.py
+++ b/impactlab_tools/utils/paralog.py
@@ -56,6 +56,10 @@ class StatusManager(object):
                 self.logpath = logpath
                 break
 
+        # Record this process in the master log
+        with open(os.path.join(logdir, "master.log"), 'a') as fp:
+            fp.write("%s %s: %d %s\n" % (time.asctime(), self.jobtitle, os.getpid(), self.logpath))
+            
         # Grab all std out
         self.sys_stdout = sys.stdout
         sys.stdout = DoubleLogger(self.logpath)
@@ -67,6 +71,8 @@ class StatusManager(object):
 
     def claim(self, dirpath):
         """Claim a directory."""
+        status_path = StatusManager.claiming_filepath(dirpath, self.jobname)
+
         if not os.path.exists(dirpath):
             os.makedirs(os.path.abspath(dirpath))
         elif self.is_claimed(dirpath):

--- a/impactlab_tools/utils/paralog.py
+++ b/impactlab_tools/utils/paralog.py
@@ -56,9 +56,12 @@ class StatusManager(object):
                 self.logpath = logpath
                 break
 
-        # Record this process in the master log
-        with open(os.path.join(logdir, "master.log"), 'a') as fp:
-            fp.write("%s %s: %d %s\n" % (time.asctime(), self.jobtitle, os.getpid(), self.logpath))
+        try:
+            # Record this process in the master log
+            with open(os.path.join(logdir, "master.log"), 'a') as fp:
+                fp.write("%s %s: %d %s\n" % (time.asctime(), self.jobtitle, os.getpid(), self.logpath))
+        except:
+            print "Warning: Could not append to master log."
             
         # Grab all std out
         self.sys_stdout = sys.stdout
@@ -71,8 +74,6 @@ class StatusManager(object):
 
     def claim(self, dirpath):
         """Claim a directory."""
-        status_path = StatusManager.claiming_filepath(dirpath, self.jobname)
-
         if not os.path.exists(dirpath):
             os.makedirs(os.path.abspath(dirpath))
         elif self.is_claimed(dirpath):

--- a/impactlab_tools/utils/versions.py
+++ b/impactlab_tools/utils/versions.py
@@ -81,17 +81,23 @@ def check_version(input_list, check_git=False):
             ind = mod.index("=")
             modules[mod[:ind]] = mod[ind:].rstrip("\n").lstrip("=")
 
-    # Read in all repos under my home directory
-    repos = sp.check_output(
-        "find ~/ -name '.git'", shell=True).split(".git\n")[:-1]
-
     git = {}
-    for repo in repos:
-        name = repo.split("/")[-2]
-        git[name] = sp.check_output(
-            "cd " + repo + " && git log --format='%H' -n 1",
-            shell=True).rstrip("\n")
+    if check_git:
+        # Read in all repos under my home directory
+        repos = sp.check_output(
+            "find ~/ -name '.git'", shell=True).split(".git\n")[:-1]
 
+        for repo in repos:
+            name = repo.split("/")[-2]
+            git[name] = sp.check_output(
+                "cd " + repo + " && git log --format='%H' -n 1",
+                shell=True).rstrip("\n")
+
+    if 'self' in input_list:
+        version = sp.check_output("git log --format='%H' -n 1", shell=True).rstrip("\n")
+        if "\n" not in version:
+            git['self'] = version
+            
     # Iterate through the input_list and find if the target is in
     # either the modules or the git dictionary, or not at all.
     rtDict = {}
@@ -112,3 +118,7 @@ def check_version(input_list, check_git=False):
         rtDict[tgt] = info
 
     return rtDict
+
+if __name__ == '__main__':
+    print check_version(['self', 'impact-calculations', 'metacsv', 'impactlab-tools', 'scipy', 'open-estimate'])
+    

--- a/impactlab_tools/utils/versions.py
+++ b/impactlab_tools/utils/versions.py
@@ -120,5 +120,5 @@ def check_version(input_list, check_git=False):
     return rtDict
 
 if __name__ == '__main__':
-    print check_version(['self', 'impact-calculations', 'metacsv', 'impactlab-tools', 'scipy', 'open-estimate'])
+    print(check_version(['self', 'impact-calculations', 'metacsv', 'impactlab-tools', 'scipy', 'open-estimate']))
     


### PR DESCRIPTION
This PR includes two unrelated changes (I'd been sitting on one, waiting until there was more to change, accidentally included it here, and decided it wasn't worth splitting out).

1. Paralog now keeps a master log, which includes the process PIDs that it creates.
2. The versions tool now properly does not check git if the `check_git` flag is false, but can check the local code for a git version.

The second change is the one I need right now, but the first change will be useful to working with the RAs too.