### PR TITLE
Fix KeyError in doctest from new xarray v0.14.0 release

### DIFF
--- a/impactlab_tools/gcp/reindex.py
+++ b/impactlab_tools/gcp/reindex.py
@@ -1,10 +1,11 @@
 
 from __future__ import absolute_import
 
-import xarray as xr
+import os
+
 import numpy as np
 import toolz
-import os
+import xarray as xr
 
 import impactlab_tools.assets
 
@@ -174,10 +175,12 @@ def hierid_to_shapenum(data, dim='hierid', new_dim='SHAPENUM', inplace=False):
         raise IndexError(
             'Not all values in "{}" found in "hierid"'.format(dim))
 
-    res.coords[dim] = (
-        mapping
-        .sel(hierid=res.coords[dim].astype(unicode))
-        .SHAPENUM.values)
+    # Insert SHAPENUM values where "dim" values match with mapping['hierid'].
+    # Needed rewrite because `where()` and prev. approach did not work in
+    # xarray v0.14.0.
+    res.coords[dim] = mapping.isel(
+        hierid=mapping['hierid'].isin(res[dim].astype(unicode))
+    )['SHAPENUM'].values
 
     res = res.rename({dim: new_dim})
     return res

--- a/whatsnew.rst
+++ b/whatsnew.rst
@@ -12,6 +12,8 @@ v0.4.0
 
  - resolve warning message from upstream ``pyyaml`` deprecation (:issue:`447`)
 
+ - work around bug from :py:func:`impactlab_tools.gcp.reindex.hierid_to_shapenum` throwing ``KeyError`` when using ``xarray`` v0.14.0 (:issue:`455`)
+
  - minor fixes to documentation
 
 v0.3.1 (March 19, 2018)


### PR DESCRIPTION
Note, the previous method this commit is replacing does not
appear to be deprecated by the new xarray version. But, this change
is still needed to run properly, so this may be an upstream
regression in xarray.

My workaround was basically switching it from a by-value indexing to a boolean indexing operation. Either way, we take those indexed
values and plug them back into `res.coords[dim]`.

 - [x] closes #455
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 impactlab_tools tests docs``
 - [x] whatsnew entry
