### PR TITLE
Poke the CI dragon - dropping gdal pkg to fix RTD build

### DIFF
--- a/requirements_conda.txt
+++ b/requirements_conda.txt
@@ -5,6 +5,5 @@ pandas
 scipy
 bottleneck
 geopandas
-gdal
 dask
 matplotlib


### PR DESCRIPTION
Fix failing readthedocs builds.