### PR TITLE
Exception logger

### DIFF
--- a/impactlab_tools/utils/paralog.py
+++ b/impactlab_tools/utils/paralog.py
@@ -135,6 +135,10 @@ class StatusManager(object):
             to be appended to `self.logpath` to create an extra log file 
         msg: str
             to be written to the extra log file 
+
+        Returns 
+        --------
+        str : the extra log file path. 
         '''
 
         filepath = self.logpath[:-4] + suffix + '.log'
@@ -142,6 +146,7 @@ class StatusManager(object):
         with open(filepath, 'a') as f:
             f.write(msg)
 
+        return filepath 
 
     @staticmethod
     def globalstatus_filepath(dirpath):

--- a/impactlab_tools/utils/paralog.py
+++ b/impactlab_tools/utils/paralog.py
@@ -124,29 +124,17 @@ class StatusManager(object):
 
         return False
 
-    def extra_log(self, msg, suffix=''):
-
-        ''' writes some extra information on the job to an extra log file identified by self.logpath + a suffix. 
+    def log_message(self, msg):
+        ''' writes some extra information on the job to the log file. 
         
         Parameters
         ----------
-
-        suffix: str 
-            to be appended to `self.logpath` to create an extra log file 
         msg: str
-            to be written to the extra log file 
-
-        Returns 
-        --------
-        str : the extra log file path. 
+            to be written to the log file
         '''
 
-        filepath = self.logpath[:-4] + suffix + '.log'
-        
-        with open(filepath, 'a') as f:
-            f.write(msg)
-
-        return filepath 
+        assert isinstance(sys.stdout, DoubleLogger)
+        sys.stdout.log_only(msg)
 
     @staticmethod
     def globalstatus_filepath(dirpath):
@@ -183,6 +171,9 @@ class DoubleLogger(object):
         self.terminal.write(message)
         self.log.write(message)
 
+    def log_only(self, message):
+        self.log.write(message + "\n")
+        
     def close(self):
         self.log.close()
 

--- a/impactlab_tools/utils/paralog.py
+++ b/impactlab_tools/utils/paralog.py
@@ -138,7 +138,7 @@ class StatusManager(object):
         '''
 
         filepath = self.logpath[:-4] + suffix + '.log'
-        assert os.path.exists(filepath)
+        
         with open(filepath, 'a') as f:
             f.write(msg)
 

--- a/impactlab_tools/utils/paralog.py
+++ b/impactlab_tools/utils/paralog.py
@@ -124,6 +124,25 @@ class StatusManager(object):
 
         return False
 
+    def extra_log(self, suffix, msg):
+
+        ''' writes some extra information on the job to an extra log file identified by self.logpath + a suffix. 
+        
+        Parameters
+        ----------
+
+        suffix: str 
+            to be appended to `self.logpath` to create an extra log file 
+        msg: str
+            to be written to the extra log file 
+        '''
+
+        filepath = self.logpath[:-4] + suffix + '.log'
+        assert os.path.exists(filepath)
+        with open(filepath, 'a') as f:
+            f.write(msg)
+
+
     @staticmethod
     def globalstatus_filepath(dirpath):
         """The path to the global status for the directory."""

--- a/impactlab_tools/utils/paralog.py
+++ b/impactlab_tools/utils/paralog.py
@@ -124,7 +124,7 @@ class StatusManager(object):
 
         return False
 
-    def extra_log(self, suffix='', msg):
+    def extra_log(self, msg, suffix=''):
 
         ''' writes some extra information on the job to an extra log file identified by self.logpath + a suffix. 
         

--- a/impactlab_tools/utils/paralog.py
+++ b/impactlab_tools/utils/paralog.py
@@ -124,7 +124,7 @@ class StatusManager(object):
 
         return False
 
-    def extra_log(self, suffix, msg):
+    def extra_log(self, suffix='', msg):
 
         ''' writes some extra information on the job to an extra log file identified by self.logpath + a suffix. 
         

--- a/tests/utils/test_paralog.py
+++ b/tests/utils/test_paralog.py
@@ -43,29 +43,28 @@ def test_extra_log():
     ''' split tests by input :
     - two different instances of Status Manager with different job names and different suffizes => two different files 
     - successive loggings => appends to file 
-    - non str suffix => TypeError
-    - non str msg => TypeError
     '''
 
-    statman1 = paralog.StatusManager(jobname='test', jobtitle='Testing process', logdir='logs', timeout=60*60)
-    statman1.extra_log(suffix='-extra', msg='msg in extra log')
-    # statman2 = paralog.StatusManager(jobname='test_2', jobtitle='Testing process 2', logdir='logs', timeout=60*60)
-    # statman2.extra_log(suffix='-extra', msg='msg in second extra log')
+    statman0 = paralog.StatusManager(jobname='test', jobtitle='Testing process', logdir='testing-paralog', timeout=60*60)
+    statman0.extra_log(suffix='-extra', msg='msg in first extra log')
+    statman1 = paralog.StatusManager(jobname='test', jobtitle='Testing process', logdir='testing-paralog', timeout=60*60)
+    statman1.extra_log(suffix='-extra', msg='msg in second extra log')
 
-    # assert os.path.exists("logs/test-1-extra.log")
-    # assert os.path.exists("logs/test-2-extra.log")
-    # with open("logs/test-1-extra.log", 'r') as fp:
-    #     assert fp.read()=="msg in extra log"
+    assert os.path.exists("testing-paralog/test-0-extra.log")
+    assert os.path.exists("testing-paralog/test-1-extra.log")
+    with open("testing-paralog/test-0-extra.log", 'r') as fp:
+        assert fp.read()=="msg in first extra log"
 
-    # with open("logs/test-2-extra.log", 'r') as fp:
-    #     assert fp.read()=="msg in second extra log"
+    with open("testing-paralog/test-1-extra.log", 'r') as fp:
+        assert fp.read()=="msg in second extra log"
 
-    # statman2.extra_log(suffix='-extra', msg=' and another msg in second extra log')
+    statman1.extra_log(suffix='-extra', msg=' and another msg in second extra log')
 
-    # with open("logs/test-2-extra.log", 'r') as fp:
-    #     assert fp.read()=="msg in second extra log and another msg in second extra log"
+    with open("testing-paralog/test-1-extra.log", 'r') as fp:
+        assert fp.read()=="msg in second extra log and another msg in second extra log"
 
-    # with pytest.raises(TypeError):
-    #     statman2.extra_log(suffix=1, msg="integer suffix should not work")
-    #     statman2.extra_log(suffix='-extra', msg=1)
+    del statman1
+    del statman0
+
+    shutil.rmtree('testing-paralog')
 

--- a/tests/utils/test_paralog.py
+++ b/tests/utils/test_paralog.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import shutil
 from impactlab_tools.utils import paralog
+import os 
 
 def test_claiming():
     statman1 = paralog.StatusManager('test', 'Testing process', 'testing-paralog', 60*60)
@@ -36,3 +37,35 @@ def test_claiming():
         print(fp.read())
 
     shutil.rmtree('testing-paralog')
+
+def test_extra_log():
+
+    ''' split tests by input :
+    - two different instances of Status Manager with different job names and different suffizes => two different files 
+    - successive loggings => appends to file 
+    - non str suffix => TypeError
+    - non str msg => TypeError
+    '''
+
+    statman1 = paralog.StatusManager(jobname='test', jobtitle='Testing process', logdir='logs', timeout=60*60)
+    statman1.extra_log(suffix='-extra', msg='msg in extra log')
+    # statman2 = paralog.StatusManager(jobname='test_2', jobtitle='Testing process 2', logdir='logs', timeout=60*60)
+    # statman2.extra_log(suffix='-extra', msg='msg in second extra log')
+
+    # assert os.path.exists("logs/test-1-extra.log")
+    # assert os.path.exists("logs/test-2-extra.log")
+    # with open("logs/test-1-extra.log", 'r') as fp:
+    #     assert fp.read()=="msg in extra log"
+
+    # with open("logs/test-2-extra.log", 'r') as fp:
+    #     assert fp.read()=="msg in second extra log"
+
+    # statman2.extra_log(suffix='-extra', msg=' and another msg in second extra log')
+
+    # with open("logs/test-2-extra.log", 'r') as fp:
+    #     assert fp.read()=="msg in second extra log and another msg in second extra log"
+
+    # with pytest.raises(TypeError):
+    #     statman2.extra_log(suffix=1, msg="integer suffix should not work")
+    #     statman2.extra_log(suffix='-extra', msg=1)
+

--- a/tests/utils/test_paralog.py
+++ b/tests/utils/test_paralog.py
@@ -40,9 +40,13 @@ def test_claiming():
 
 def test_extra_log():
 
-    ''' split tests by input :
+    ''' 
+    split tests by input :
     - two different instances of Status Manager with different job names and different suffizes => two different files 
     - successive loggings => appends to file 
+    
+    This test creates files that have to be deleted for the test to run sucessfully again. The test deletes these files at the 
+    end, but if it fails before, the user should manually delete these files after fixing the test. 
     '''
 
     statman0 = paralog.StatusManager(jobname='test', jobtitle='Testing process', logdir='testing-paralog', timeout=60*60)

--- a/tests/utils/test_paralog.py
+++ b/tests/utils/test_paralog.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import shutil
 from impactlab_tools.utils import paralog
-import os 
+import os, sys
 
 def test_claiming():
     statman1 = paralog.StatusManager('test', 'Testing process', 'testing-paralog', 60*60)
@@ -38,39 +38,27 @@ def test_claiming():
 
     shutil.rmtree('testing-paralog')
 
-def test_extra_log():
+def test_log_message():
 
     ''' 
-    split tests by input :
-    - two different instances of Status Manager with different job names and different suffizes => two different files 
-    - successive loggings => appends to file 
+    test that both normal print messages go to the log and log_message calls go to the log.
     
     This test creates files that have to be deleted for the test to run sucessfully again. The test deletes these files at the 
     end, but if it fails before, the user should manually delete these files after fixing the test. 
     '''
 
-    statman0 = paralog.StatusManager(jobname='test', jobtitle='Testing process', logdir='testing-paralog', timeout=60*60)
-    extrapath = statman0.extra_log(suffix='-extra', msg='msg in first extra log')
-    assert extrapath=="testing-paralog/test-0-extra.log"
+    statman = paralog.StatusManager(jobname='test', jobtitle='Testing process', logdir='testing-paralog', timeout=60*60)
+    print("Printed message")
+    statman.log_message(msg='Log-only message')
+    assert statman.logpath=="testing-paralog/test-0.log"
 
-    statman1 = paralog.StatusManager(jobname='test', jobtitle='Testing process', logdir='testing-paralog', timeout=60*60)
-    statman1.extra_log(suffix='-extra', msg='msg in second extra log')
+    del statman
 
-    assert os.path.exists("testing-paralog/test-0-extra.log")
-    assert os.path.exists("testing-paralog/test-1-extra.log")
-    with open("testing-paralog/test-0-extra.log", 'r') as fp:
-        assert fp.read()=="msg in first extra log"
+    assert os.path.exists("testing-paralog/test-0.log")
+    with open("testing-paralog/test-0.log", 'r') as fp:
+        assert fp.readline() == "Printed message\n"
+        assert fp.readline() == "Log-only message\n"
 
-    with open("testing-paralog/test-1-extra.log", 'r') as fp:
-        assert fp.read()=="msg in second extra log"
-
-    statman1.extra_log(suffix='-extra', msg=' and another msg in second extra log')
-
-    with open("testing-paralog/test-1-extra.log", 'r') as fp:
-        assert fp.read()=="msg in second extra log and another msg in second extra log"
-
-    del statman1
-    del statman0
 
     shutil.rmtree('testing-paralog')
 

--- a/tests/utils/test_paralog.py
+++ b/tests/utils/test_paralog.py
@@ -46,7 +46,9 @@ def test_extra_log():
     '''
 
     statman0 = paralog.StatusManager(jobname='test', jobtitle='Testing process', logdir='testing-paralog', timeout=60*60)
-    statman0.extra_log(suffix='-extra', msg='msg in first extra log')
+    extrapath = statman0.extra_log(suffix='-extra', msg='msg in first extra log')
+    assert extrapath=="testing-paralog/test-0-extra.log"
+
     statman1 = paralog.StatusManager(jobname='test', jobtitle='Testing process', logdir='testing-paralog', timeout=60*60)
     statman1.extra_log(suffix='-extra', msg='msg in second extra log')
 


### PR DESCRIPTION
 - [x] part of #463
 - [x] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 impactlab_tools tests docs``
 - [ ] whatsnew entry

@emileten I'm sorry to change your code, but I don't see a use-case for starting a new log in `paralog`. If we wanted a new log, we can just create it elsewhere. And I didn't like having multiple pointers open to the same file. Even though it seemed to work fine, I don't know how that will act when we switch to proper multithreading.