### PR TITLE
Simplify dependencies: Add optional viz, complete.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,13 @@ dependencies = [
 "Bug Tracker" = "https://github.com/ClimateImpactLab/impactlab-tools/issues"
 
 [project.optional-dependencies]
-complete = ["impactlab-tools[vis,dev]"]
-dev = [
-    "impactlab-tools[complete]",
-    "ruff",
+complete = ["impactlab-tools[vis,docs,test]"]
+docs = [
     "Sphinx",
     "sphinx-rtd-theme",
+]
+test = [
+    "ruff",
     "pytest>=3.0",
     "pytest-cov>=2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "geopandas",
-    "h5netcdf",
-    "matplotlib",
     "numpy>=1.7",
     "pandas>=0.15",
     "pyyaml",
@@ -33,14 +30,18 @@ dependencies = [
 "Bug Tracker" = "https://github.com/ClimateImpactLab/impactlab-tools/issues"
 
 [project.optional-dependencies]
-docs = [
+complete = ["impactlab-tools[vis,dev]"]
+dev = [
+    "impactlab-tools[complete]",
+    "ruff",
     "Sphinx",
     "sphinx-rtd-theme",
-]
-test = [
-    "ruff",
     "pytest>=3.0",
     "pytest-cov>=2.0",
+]
+viz = [
+    "geopandas",
+    "matplotlib",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 "Bug Tracker" = "https://github.com/ClimateImpactLab/impactlab-tools/issues"
 
 [project.optional-dependencies]
-complete = ["impactlab-tools[vis,docs,test]"]
+complete = ["impactlab-tools[viz,docs,test]"]
 docs = [
     "Sphinx",
     "sphinx-rtd-theme",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 # This is only used by Github and Github Actions.
 numpy==1.26.3
-xarray==2024.5.0
+xarray[complete]==2024.5.0
 pandas==2.2.1
 scipy==1.13.0
-h5netcdf==1.3.0
 geopandas==0.14.3
 matplotlib==3.8.3
 Sphinx==7.3.7

--- a/whatsnew.rst
+++ b/whatsnew.rst
@@ -6,6 +6,10 @@ These are new features and improvements of note in each release.
 Unreleased
 ----------
 
+ - Drop unused "h5netcdf" dependency. Make "matplotlib", "geopandas" optional dependencies.
+
+ - Add new extras for optional dependencies: ``impactlab-tools[viz]``, ``impactlab-tools[complete]``.
+
  - Minor code cleanup, style update.
 
  - Update ruff lint section format in pyproject.toml


### PR DESCRIPTION
This makes `geopandas` and `matplotlib` optional dependencies under `impactlab-tools[viz]` as they are only used in the "visualization" submodule. 

`h5netcdf` is also no longer a dependency as it's not something used directly by the package. Users are instead expected to install and configure whatever netcdf suite works for their system and xarray.

Making these dependencies optional hopefully lightens the burden of impactlab-tools.

Users can install _everything_ with `pip install impactlab-tools[complete]`.