### PR TITLE
Minor style update for ruff 0.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ sphinx-rtd-theme==3.0.2
 pytest==8.3.3
 pytest-cov==6.0.0
 pyyaml==6.0.2
-ruff==0.6.8
+ruff==0.8.1

--- a/src/impactlab_tools/utils/paralog.py
+++ b/src/impactlab_tools/utils/paralog.py
@@ -101,7 +101,9 @@ class StatusManager:
         status_path = StatusManager.claiming_filepath(dirpath, self.jobname)
         try:
             with open(status_path, 'w') as fp:
-                fp.write(f"{os.getpid():d} {self.jobtitle}: {self.logpath}\n")
+                fp.write(
+                    f"{os.getpid():d} {self.jobtitle}: {self.logpath}\n"
+                )
         except Exception:
             print("CAUGHT A WILD EXCEPTION BUT IGNORING IT WITHOUT LOGGING IT!")
             return False # Writing error: cannot calim directory

--- a/src/impactlab_tools/utils/paralog.py
+++ b/src/impactlab_tools/utils/paralog.py
@@ -64,7 +64,7 @@ class StatusManager:
         if not os.path.exists(logdir):
             os.makedirs(logdir)
         for ii in itertools.count():
-            logpath = os.path.join(logdir, "%s-%d.log" % (jobname, ii))
+            logpath = os.path.join(logdir, f"{jobname}-{ii:d}.log")
             if not os.path.exists(logpath):
                 self.logpath = logpath
                 break
@@ -73,12 +73,7 @@ class StatusManager:
             # Record this process in the master log
             with open(os.path.join(logdir, "master.log"), 'a') as fp:
                 fp.write(
-                    "%s %s: %d %s\n" % (
-                        time.asctime(),
-                        self.jobtitle,
-                        os.getpid(),
-                        self.logpath
-                    )
+                    f"{time.asctime()} {self.jobtitle}: {os.getpid():d} {self.logpath}\n"
                 )
         except Exception:
             print("CAUGHT A WILD EXCEPTION BUT IGNORING IT WITHOUT LOGGING IT!")
@@ -106,7 +101,7 @@ class StatusManager:
         status_path = StatusManager.claiming_filepath(dirpath, self.jobname)
         try:
             with open(status_path, 'w') as fp:
-                fp.write("%d %s: %s\n" % (os.getpid(), self.jobtitle, self.logpath))
+                fp.write(f"{os.getpid():d} {self.jobtitle}: {self.logpath}\n")
         except Exception:
             print("CAUGHT A WILD EXCEPTION BUT IGNORING IT WITHOUT LOGGING IT!")
             return False # Writing error: cannot calim directory

--- a/src/impactlab_tools/utils/paralog.py
+++ b/src/impactlab_tools/utils/paralog.py
@@ -73,7 +73,8 @@ class StatusManager:
             # Record this process in the master log
             with open(os.path.join(logdir, "master.log"), 'a') as fp:
                 fp.write(
-                    f"{time.asctime()} {self.jobtitle}: {os.getpid():d} {self.logpath}\n"
+                    f"{time.asctime()} {self.jobtitle}:"
+                    f"{os.getpid():d} {self.logpath}\n"
                 )
         except Exception:
             print("CAUGHT A WILD EXCEPTION BUT IGNORING IT WITHOUT LOGGING IT!")

--- a/whatsnew.rst
+++ b/whatsnew.rst
@@ -6,6 +6,7 @@ These are new features and improvements of note in each release.
 Unreleased
 ----------
 
+ - Minor code style update.
 
 v0.6.0 (May 31, 2024)
 ---------------------


### PR DESCRIPTION
 - [x] closes #xxxx
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 impactlab_tools tests docs``
 - [x] whatsnew entry

Dependabot's ruff v0.8.1 update in #577 failed the CI linting step. The tools says using `"%"` for string formatting is too old. This PR updates code style to use f-strings so that it can pass linting in the new version of ruff.